### PR TITLE
[KFSQA-1173] Fix flickering Account edit ICR accounts AFTs when dynam…

### DIFF
--- a/features/chart_of_accounts/account_create.feature
+++ b/features/chart_of_accounts/account_create.feature
@@ -80,7 +80,8 @@ Feature: Account Creation
     And   I remember the logged in user
     And   I edit an Account having a CG account with a CG Account Responsibility ID in range 1 to 8
     And   I edit the first active Indirect Cost Recovery Account on the Account to an <ICR_account_type> Contracts & Grants Account
-    And   I submit the Account document
+    And   I submit the Account document addressing Continutaion Account errors
+    Then  the document should have no errors
     And   I display the Account document
     And   I switch to the user with the next Pending Action in the Route Log for the Account document
     And   I display the Account document
@@ -89,6 +90,7 @@ Feature: Account Creation
     Then  the Account should show an error stating the Indirect Cost Recovery Account is closed
     And   I edit the first active Indirect Cost Recovery Account on the Account to an <ICR_account_type> Contracts & Grants Account
     And   I approve the Account document
+    Then  the document should have no errors
     And   I display the Account document
     Then  APPROVED should be in the Account document Actions Taken
     Examples:

--- a/features/step_definitions/chart_of_accounts/account.rb
+++ b/features/step_definitions/chart_of_accounts/account.rb
@@ -529,9 +529,8 @@ And /^I submit the Account document addressing Continutaion Account errors$/ do
   #getting errors from page is expensive, obtain reference once that can be reused
   page_errors = $current_page.errors
   #search errors array for Continuation Account in any of the error messages
-  continutation_acct_error_exists = false
-  continutation_acct_error_exists = page_errors.any? { |s| s.include?('Continuation Account') }
-  if continutation_acct_error_exists
+  continuation_acct_error_exists = page_errors.any? { |s| s.include?('Continuation Account') }
+  if continuation_acct_error_exists
     on AccountPage do |page|
       #update the account object with changes and then use that object to edit the page
       @account.continuation_chart_code = get_aft_parameter_value(ParameterConstants::DEFAULT_CHART_CODE)


### PR DESCRIPTION
…ic data used for Account contains reference to closed or expired Continuation Account by setting Continuation Account number to new default parameter continuation account IT-CONTINU when business rule error encountered on submit.
