### PR TITLE
Changes from Exception to StandardError in an attempt to allow tests to continue after a failed scenario.

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -92,7 +92,7 @@ end
 
 at_exit { kuality.browser.close } unless ENV['DEBUG']
 
-class Exception
+class StandardError
   alias_method :old_message, :message
 
   def message


### PR DESCRIPTION
When run locally, this seems to continue to the next scenario after a failed scenario (assuming DEBUG=false or DEBUG is not set).
